### PR TITLE
Updated release CI workflow to only run when releases are published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: 'Release a new version to Github Packages'
 
 on:
-  release:
-    types: [published]
+    release:
+        types: [published]
 
 jobs:
     push_to_registry:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: 'Release a new version to Github Packages'
 
-on: release
+on:
+  release:
+    types: [published]
 
 jobs:
     push_to_registry:


### PR DESCRIPTION
Current version of release workflow has a bug where releases trigger the workflow three times. This should fix #4.