### PR TITLE
Tests & Optimizations for Large Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __debug*
 main
 data/
 
-cover.out
+*.out
+robokache.test

--- a/internal/robokache/db.go
+++ b/internal/robokache/db.go
@@ -94,6 +94,9 @@ func (doc *Document) addOwned(owner string) {
 }
 
 func clearDB() error {
+	os.RemoveAll(dataDir + "/files")
+	os.MkdirAll( dataDir + "/files", 0755)
+
 	_, err := db.Exec(`DELETE FROM document`)
 	return err
 }
@@ -133,23 +136,28 @@ func loadSampleData() error {
 
 var db *sqlx.DB
 
-// SetupDB sets up the SQLite database if it does not exist
-func init() {
-	// Create data directory
-	info, err := os.Stat(dataDir)
+func mustExistDirectory(dir string) {
+	info, err := os.Stat(dir)
 	if os.IsNotExist(err) {
-		err := os.Mkdir(dataDir, 0755)
+		err := os.Mkdir(dir, 0755)
 		if err != nil {
-			panic(fmt.Errorf("Failed to create data directory: %v", err))
+			panic(fmt.Errorf("Failed to create directory %s: %v", dir, err))
 		}
-		info, _ = os.Stat(dataDir)
+		info, _ = os.Stat(dir)
 	} else if err != nil {
 		panic(err)
 	}
-	// If dataDir exists but is not a directory, panic
+	// If dir exists but is not a directory, panic
 	if !info.IsDir() {
-		panic(fmt.Errorf("\"data\" file exists and is not a directory"))
+		panic(fmt.Errorf("\"%s\" file exists and is not a directory", dir))
 	}
+}
+
+// SetupDB sets up the SQLite database if it does not exist
+func init() {
+	// Create data directory
+	mustExistDirectory(dataDir)
+	mustExistDirectory(dataDir + "/files")
 
 	db = sqlx.MustConnect("sqlite3", dbFile)
 

--- a/internal/robokache/get.go
+++ b/internal/robokache/get.go
@@ -2,10 +2,12 @@ package robokache
 
 import (
 	"os"
+	"io"
 	"io/ioutil"
 	"database/sql"
 	"fmt"
 	"strconv"
+	"strings"
 
 	_ "github.com/mattn/go-sqlite3" // makes database/sql point to SQLite
 )
@@ -64,19 +66,20 @@ func GetDocumentChildren(userEmail string, id int) ([]Document, error) {
 	return docs, nil
 }
 
-func GetData(id int) ([]byte, error) {
+func GetData(id int) (io.ReadCloser, error) {
 	filename := dataDir + "/files/" + strconv.Itoa(id)
 
-	// If the file does not exist, return empty data
 	_, err := os.Stat(filename)
 	if os.IsNotExist(err) {
-	    return []byte{}, nil
+		// If the file does not exist, return empty data
+		r := ioutil.NopCloser(strings.NewReader(""))
+	    return r, nil
 	} else if err != nil {
 		return nil, err
 	}
-	// Read associated JSON file
-	data, err := ioutil.ReadFile(filename)
 
+	// Read associated data file
+	data, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/robokache/get.go
+++ b/internal/robokache/get.go
@@ -65,7 +65,7 @@ func GetDocumentChildren(userEmail string, id int) ([]Document, error) {
 }
 
 func GetData(id int) ([]byte, error) {
-	filename := dataDir + "/" + strconv.Itoa(id)
+	filename := dataDir + "/files/" + strconv.Itoa(id)
 
 	// If the file does not exist, return empty data
 	_, err := os.Stat(filename)

--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -197,6 +197,18 @@ func TestGetPutData(t *testing.T) {
 	assert.Equal(t, requestBody, w.Body.String())
 }
 
+func TestGetNoData(t *testing.T) {
+	clearDB(); loadSampleData()
+
+	id, _ := idToHash(1)
+	w := performRequest(router, "GET",
+			fmt.Sprintf(`/api/document/%s/data`, id),
+			signedString, nil)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", w.Body.String())
+}
+
 // Test the shortcut route to add a child with data
 func TestPostChildWithData(t *testing.T) {
 	clearDB(); loadSampleData()

--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -361,19 +361,36 @@ func TestBadToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
-func TestGetPutLargeData(t *testing.T) {
-	clearDB(); loadSampleData()
+// Benchmark to test how the application handles large files
+
+func BenchmarkGetPutLargeData(b *testing.B) {
+	var testBytes []byte
+	var testString string
+
+	// File size in MB
+	testFileSize := 1024 * 1024 * 100
+
+	testBytes = make([]byte, testFileSize)
+	for i := 0; i < testFileSize; i++ {
+		testBytes[i] = 'a' + byte(i%26)
+	}
+	testString = string(testBytes)
 
 	id, _ := idToHash(1)
-	requestBody := "This is a string to test the data saving functionality"
-	w := performRequest(router, "PUT",
-			fmt.Sprintf(`/api/document/%s/data`, id),
-			signedString, &requestBody)
-	assert.Equal(t, http.StatusOK, w.Code)
 
-	w = performRequest(router, "GET",
-			fmt.Sprintf(`/api/document/%s/data`, id),
-			signedString, &requestBody)
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, requestBody, w.Body.String())
+	// Repeat benchmark to get accurate timing data
+	for i := 0; i < b.N; i++ {
+		loadSampleData()
+		b.StartTimer()
+
+		performRequest(router, "PUT",
+				fmt.Sprintf(`/api/document/%s/data`, id),
+				signedString, &testString)
+		performRequest(router, "GET",
+				fmt.Sprintf(`/api/document/%s/data`, id),
+				signedString, nil)
+
+		b.StopTimer()
+		clearDB()
+	}
 }

--- a/internal/robokache/put.go
+++ b/internal/robokache/put.go
@@ -64,11 +64,20 @@ func EditDocument(doc Document) error {
 	return nil
 }
 
-func SetData(id int) (io.WriteCloser, error) {
+func SetData(id int, r io.Reader) error {
 	filename := dataDir + "/files/" + strconv.Itoa(id)
-	f, err := os.Create(filename)
+
+	// Open file for writing
+	file, err := os.Create(filename)
 	if err != nil {
-		return nil, err
+		return nil
 	}
-	return f, nil
+	defer file.Close()
+
+	// Use io.Copy to write without a buffer
+	_, err = io.Copy(file, r)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/robokache/put.go
+++ b/internal/robokache/put.go
@@ -3,7 +3,8 @@ package robokache
 import (
 	"fmt"
 	"database/sql"
-	"io/ioutil"
+	"io"
+	"os"
 	"strconv"
 )
 
@@ -63,11 +64,11 @@ func EditDocument(doc Document) error {
 	return nil
 }
 
-func SetData(id int, data []byte) error {
+func SetData(id int) (io.WriteCloser, error) {
 	filename := dataDir + "/files/" + strconv.Itoa(id)
-	err := ioutil.WriteFile(filename, data, 0644)
+	f, err := os.Create(filename)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return f, nil
 }

--- a/internal/robokache/put.go
+++ b/internal/robokache/put.go
@@ -64,7 +64,7 @@ func EditDocument(doc Document) error {
 }
 
 func SetData(id int, data []byte) error {
-	filename := dataDir + "/" + strconv.Itoa(id)
+	filename := dataDir + "/files/" + strconv.Itoa(id)
 	err := ioutil.WriteFile(filename, data, 0644)
 	if err != nil {
 		return err

--- a/internal/robokache/util.go
+++ b/internal/robokache/util.go
@@ -14,5 +14,5 @@ func getenv(key string, defaultValue string) string {
 
 var (
 	dataDir = getenv("ROBOKACHE_DATA_DIR", "./data")
-	dbFile  = dataDir + "/q&a.db"
+	dbFile  = dataDir + "/db.sqlite3"
 )


### PR DESCRIPTION
Added a benchmark to test performance with large files. This benchmark can be run with the -bench flag:
```
go test ./internal/robokache -bench=BenchmarkGetPutLargeData -count=1 -benchmem -memprofile memprofile.out
```

This creates a memory profile that can be viewed with the following command:
```
go tool pprof -http localhost:8080 memprofile.out
```

There are also optimizations in this PR. These were based around using Golang's IO constructs (io.Reader and io.Writer) instead of using a byte array for parsing the large HTTP requests and responses. These reduced test memory usage by approximately 50%.