### PR TITLE
hasParent Query Parameter for GET /api/document

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -15,6 +15,12 @@ paths:
     get:
       summary: Get documents
       description: Get a list of documents that are either public or associated with the current user
+      parameters:
+        - in: query
+          name: hasParent
+          schema:
+            type: boolean
+          description: If given, filter by whether the document has a parent.
       responses:
         '200':
           description: Documents

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -17,7 +17,7 @@ paths:
       description: Get a list of documents that are either public or associated with the current user
       parameters:
         - in: query
-          name: hasParent
+          name: has_parent
           schema:
             type: boolean
           description: If given, filter by whether the document has a parent.

--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -121,7 +121,7 @@ func TestGetDocumentsNoParent(t *testing.T) {
 	clearDB(); loadSampleData()
 
   // Gets root documents
-	w := performRequest(router, "GET", "/api/document?hasParent=false", signedString, nil)
+	w := performRequest(router, "GET", "/api/document?has_parent=false", signedString, nil)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response []map[string]interface{}
@@ -139,7 +139,7 @@ func TestGetDocumentsHasParent(t *testing.T) {
 	clearDB(); loadSampleData()
 
     // Gets root documents
-	w := performRequest(router, "GET", "/api/document?hasParent=true", signedString, nil)
+	w := performRequest(router, "GET", "/api/document?has_parent=true", signedString, nil)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response []map[string]interface{}

--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -117,6 +117,43 @@ func TestGetDocuments(t *testing.T) {
 	assert.Equal(t, 6, len(response))
 }
 
+func TestGetDocumentsNoParent(t *testing.T) {
+	clearDB(); loadSampleData()
+
+  // Gets root documents
+	w := performRequest(router, "GET", "/api/document?hasParent=false", signedString, nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	err := json.Unmarshal([]byte(w.Body.String()), &response)
+	assert.Nil(t, err)
+
+	// Should be able to see my root documents (2) + you root public documents (1)
+	assert.Equal(t, 3, len(response))
+	for _, doc := range response {
+		assert.Equal(t, "", doc["parent"])
+	}
+}
+
+func TestGetDocumentsHasParent(t *testing.T) {
+	clearDB(); loadSampleData()
+
+    // Gets root documents
+	w := performRequest(router, "GET", "/api/document?hasParent=true", signedString, nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	err := json.Unmarshal([]byte(w.Body.String()), &response)
+	assert.Nil(t, err)
+
+	// Should be able to see my child documents (2) + you child public documents (1)
+	assert.Equal(t, 3, len(response))
+	for _, doc := range response {
+		t.Log(doc)
+		assert.NotEqual(t, "", doc["parent"])
+	}
+}
+
 func TestGetMePrivateDocument(t *testing.T) {
 	clearDB(); loadSampleData()
 

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -3,6 +3,7 @@ package robokache
 import (
 	"net/http"
 	"strings"
+	"fmt"
 	"github.com/gin-gonic/gin"
 )
 
@@ -31,6 +32,11 @@ func AddGUI(r *gin.Engine) {
 	r.Static("/docs", "./api")
 }
 
+// Query parameters for Document get request
+type GetDocumentQuery struct {
+	HasParent *bool `form:"hasParent"`
+}
+
 // SetupRouter sets up the router
 func SetupRouter() *gin.Engine {
 	r := gin.Default()
@@ -43,8 +49,15 @@ func SetupRouter() *gin.Engine {
 			// Get user
 			userEmail := c.GetString("userEmail")
 
+			// Parse query parameters into queryParams struct
+			var queryParams GetDocumentQuery
+			err := c.ShouldBindQuery(&queryParams)
+			if err != nil {
+				handleErr(c, fmt.Errorf("Bad Request: Error parsing query parameters"))
+			}
+
 			// Get user's documents from database
-			documents, err := GetDocuments(userEmail)
+			documents, err := GetDocuments(userEmail, queryParams.HasParent)
 			if err != nil {
 				handleErr(c, err)
 				return

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -34,7 +34,7 @@ func AddGUI(r *gin.Engine) {
 
 // Query parameters for Document get request
 type GetDocumentQuery struct {
-	HasParent *bool `form:"hasParent"`
+	HasParent *bool `form:"has_parent"`
 }
 
 // SetupRouter sets up the router


### PR DESCRIPTION
Added ability to use the hasParent query parameter on the /api/document endpoint. Also updated tests and API documentation. Fixes #21. 