### PR TITLE
404 on access to private document on /children endpoint

### DIFF
--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -273,7 +273,7 @@ func TestGetChildren(t *testing.T) {
 func TestGetChildrenPrivateDoc(t *testing.T) {
 	clearDB(); loadSampleData()
 
-	// Can see all of my own child documents
+	// Can't view other users' child documents
 	hashedID, _ := idToHash(6)
 	w := performRequest(router, "GET", "/api/document/" + hashedID + "/children", &signedString, nil)
 	assert.Equal(t, http.StatusNotFound, w.Code)

--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -270,6 +270,15 @@ func TestGetChildren(t *testing.T) {
 	assert.Equal(t, 2, len(response))
 }
 
+func TestGetChildrenPrivateDoc(t *testing.T) {
+	clearDB(); loadSampleData()
+
+	// Can see all of my own child documents
+	hashedID, _ := idToHash(6)
+	w := performRequest(router, "GET", "/api/document/" + hashedID + "/children", &signedString, nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestGetPutData(t *testing.T) {
 	clearDB(); loadSampleData()
 

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -171,6 +171,14 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
+			// Get document from database to ensure we have permission
+			// to access this endpoint
+			_, err = GetDocument(userEmail, id)
+			if err != nil {
+				handleErr(c, err)
+				return
+			}
+
 			// Get documents that have this as a parent
 			documents, err := GetDocumentChildren(userEmail, id)
 			if err != nil {


### PR DESCRIPTION
Return a 404 when attempting to access a private document on the /api/document/:id/children endpoint. This ensures a consistent response across the API when accessing private documents. Fixes #29.