### PR TITLE
Added "metadata" and "created_at" fields

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Robokache
   description: Large object document store for ROBOKOP
-  version: 3.1.0
+  version: 3.2.0
   contact:
     email: patrick@covar.com
   license:
@@ -32,9 +32,7 @@ paths:
                 items:
                   allOf:
                    - $ref: '#/components/schemas/Document'
-                   - properties:
-                       id:
-                         type: string
+                   - $ref: '#/components/schemas/DocumentResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     post:
@@ -60,7 +58,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Document'
+                allOf:
+                 - $ref: '#/components/schemas/Document'
+                 - $ref: '#/components/schemas/DocumentResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
@@ -106,10 +106,8 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: '#/components/schemas/Document'
-                    - properties:
-                        id:
-                          type: string
+                   - $ref: '#/components/schemas/Document'
+                   - $ref: '#/components/schemas/DocumentResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
     post:
@@ -168,6 +166,13 @@ components:
           type: integer
         metadata:
           type: object
+    DocumentResponse:
+      properties:
+        id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
   securitySchemes:
     google:
       type: http

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Robokache
   description: Large object document store for ROBOKOP
-  version: 3.0.0
+  version: 3.1.0
   contact:
     email: patrick@covar.com
   license:
@@ -166,6 +166,8 @@ components:
           type: string
         visibility:
           type: integer
+        metadata:
+          type: object
   securitySchemes:
     google:
       type: http

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/mattn/go-sqlite3 v1.14.2
+	github.com/sirupsen/logrus v1.6.0
 	github.com/speps/go-hashids v2.0.0+incompatible
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -38,10 +39,13 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/speps/go-hashids v1.0.0 h1:jdFC07PrExRM4Og5Ev4411Tox75aFpkC77NlmutadNI=
 github.com/speps/go-hashids v2.0.0+incompatible h1:kSfxGfESueJKTx0mpER9Y/1XHl+FVQjtCqRyYcviFbw=
 github.com/speps/go-hashids v2.0.0+incompatible/go.mod h1:P7hqPzMdnZOfyIk+xrlG1QaSMw+gCBdHKsBDnhpaZvc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -54,6 +58,7 @@ golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/robokache/db.go
+++ b/internal/robokache/db.go
@@ -1,6 +1,7 @@
 package robokache
 
 import (
+	"time"
 	"encoding/json"
 	"database/sql/driver"
 	"github.com/jmoiron/sqlx"
@@ -42,6 +43,8 @@ type Document struct {
 	Visibility *visibility     `db:"visibility" json:"visibility"`
 	// Key value store that contains other data about the object
 	Metadata Metadata `db:"metadata" json:"metadata"`
+	// Creation time field, automatically set
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
 }
 
 type visibility int
@@ -187,7 +190,8 @@ func init() {
 			parent INTEGER,
 			owner TEXT,
 			visibility INTEGER,
-			metadata TEXT
+			metadata TEXT,
+			created_at TIMESTAMP  NOT NULL  DEFAULT current_timestamp
 		);`
 
 	db.MustExec(sqlStmt)

--- a/internal/robokache/post.go
+++ b/internal/robokache/post.go
@@ -26,9 +26,9 @@ func PostDocument(doc Document) (int, error) {
 	}
 	// Add question to DB
 	result, err := db.Exec(`
-		INSERT INTO document(owner, parent, visibility) VALUES
-		(?, ?, ?);
-	`, doc.Owner, doc.Parent, doc.Visibility)
+		INSERT INTO document(owner, parent, visibility, metadata) VALUES
+    (?, ?, ?, ?);
+	`, doc.Owner, doc.Parent, doc.Visibility, doc.Metadata)
 
 	if err != nil {
 		return -1, err

--- a/internal/robokache/put.go
+++ b/internal/robokache/put.go
@@ -53,9 +53,13 @@ func EditDocument(doc Document) error {
 	// Update document
 	result, err := db.Exec(`
 		UPDATE document SET
-		visibility=?, parent=?
+		visibility=?, parent=?, metadata=?
 		WHERE id=?;
-	`, doc.Visibility, doc.Parent, doc.ID)
+	`, doc.Visibility, doc.Parent, doc.Metadata, doc.ID)
+
+	if err != nil {
+		return err
+	}
 
 	_, err = result.RowsAffected()
 	if err != nil {

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -5,7 +5,17 @@ import (
 	"strings"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
+
+// Initialize logging
+func init() {
+	if gin.Mode() == gin.DebugMode {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.WarnLevel)
+	}
+}
 
 func handleErr(c *gin.Context, err error) {
 	errorMsg := err.Error()

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -321,6 +321,9 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
+			log.WithFields(
+				log.Fields{"doc" : fmt.Sprintf("%+v", doc)}).Debug("Updating document")
+
 			// Set the document owner from the user's Google Auth
 			doc.Owner = userEmail
 			// Set the document based on the URL param


### PR DESCRIPTION
Documents can represent both questions and answers, but questions and answers need some specific fields for the planned UI. Specifically, these are the fields that are required:

- has_answers: Question documents
- source_ara: Answer documents
- name: Question documents
- current_status: Answer documents (to hold information on whether the answer is processing, success, etc)

The most general way to handle this is to add a metadata field which can store a map of strings to values. The backend code verifies that the metadata field is a dictionary with string keys, but has no further awareness of the values.

In addition, a created_at field was added that is auto updated and can't be set. This is useful for storing the "ask date" of questions and answers.