### PR TITLE
Document endpoints returning null fix

### DIFF
--- a/internal/robokache/get.go
+++ b/internal/robokache/get.go
@@ -12,8 +12,7 @@ import (
 
 // GetDocument gets all documents where owner = user OR visibility >= public.
 func GetDocuments(userEmail *string, hasParent *bool) ([]Document, error) {
-	// Slice of rows
-	var docs []Document
+	docs := make([]Document, 0)
 	var err error
 
 	queryString := `
@@ -59,7 +58,7 @@ func GetDocument(userEmail *string, id int) (Document, error) {
 
 // Get all the documents with given id as the parent
 func GetDocumentChildren(userEmail *string, id int) ([]Document, error) {
-	var docs []Document
+	docs := make([]Document, 0)
 
 	err := db.Select(&docs, `
 		SELECT * FROM document


### PR DESCRIPTION
/api/document and /api/document/:id/children endpoints are currently returning "null" in the body when there are no matching documents. This is problematic for applications that expect a JSON response. The fix in this PR uses a zero length slice instead of a nil slice so that it is serialized as "[]" rather than "null". 