### PR TITLE
Switched API to return JSON responses

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1,8 +1,9 @@
 openapi: 3.0.3
+
 info:
   title: Robokache
   description: Large object document store for ROBOKOP
-  version: 3.2.0
+  version: 4.0.0
   contact:
     email: patrick@covar.com
   license:
@@ -44,7 +45,13 @@ paths:
               $ref: '#/components/schemas/Document'
       responses:
         '201':
-          $ref: '#/components/responses/IdOfCreated'
+          description: ID of created document
+          content:
+            application/json:
+              schema:
+                allOf:
+                 - $ref: '#/components/schemas/OkResponse'
+                 - $ref: '#/components/schemas/IdOfCreated'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
   /api/document/{id}:
@@ -64,7 +71,7 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
-          $ref: '#/components/responses/NoSuchDocument'
+          $ref: '#/components/responses/NoSuchDocumentError'
     put:
       summary: Update fields of document
       parameters:
@@ -76,11 +83,15 @@ paths:
               $ref: '#/components/schemas/Document'
       responses:
         '200':
-          description: Successfully updated
+          description: Document successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
-          $ref: '#/components/responses/NoSuchDocument'
+          $ref: '#/components/responses/NoSuchDocumentError'
     delete:
       summary: Delete document by ID
       parameters:
@@ -88,10 +99,14 @@ paths:
       responses:
         '200':
           description: Deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
-          $ref: '#/components/responses/NoSuchDocument'
+          $ref: '#/components/responses/NoSuchDocumentError'
   /api/document/{id}/children:
     get:
       summary: Get documents that have this document as a parent
@@ -110,6 +125,8 @@ paths:
                    - $ref: '#/components/schemas/DocumentResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NoSuchDocumentError'
     post:
       summary: Create a new child document and set data field
       description: Shorthand to create a child document and set the data field using only one route. This creates the document with default values for fields.
@@ -118,12 +135,19 @@ paths:
       requestBody:
         description: Data object
         content:
-          application/json:
+          application/octet-stream:
             schema:
               type: string
+              format: binary
       responses:
         '200':
-          $ref: '#/components/responses/IdOfCreated'
+          description: New document created successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                 - $ref: '#/components/schemas/OkResponse'
+                 - $ref: '#/components/schemas/IdOfCreated'
   /api/document/{id}/data:
     get:
       summary: Get the data associated with this document
@@ -153,6 +177,10 @@ paths:
       responses:
         '200':
           description: Successfully Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
 
@@ -173,6 +201,27 @@ components:
         created_at:
           type: string
           format: date-time
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: error
+        message:
+          type: string
+          example: Detailed error message
+    OkResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+    IdOfCreated:
+      type: object
+      properties:
+        id:
+          type: string
+          example: D8JnjJB5
   securitySchemes:
     google:
       type: http
@@ -181,13 +230,16 @@ components:
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid
-    NoSuchDocument:
-      description: Document ID not found
-    IdOfCreated:
-      description: ID of created document
       content:
-        application/text:
-          example: 1234
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    NoSuchDocumentError:
+      description: Document not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
   parameters:
     PathId:
       name: id

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -204,18 +204,12 @@ components:
     ErrorResponse:
       type: object
       properties:
-        status:
-          type: string
-          example: error
         message:
           type: string
           example: Detailed error message
     OkResponse:
       type: object
-      properties:
-        status:
-          type: string
-          example: ok
+      properties: {}
     IdOfCreated:
       type: object
       properties:

--- a/internal/robokache/auth.go
+++ b/internal/robokache/auth.go
@@ -99,12 +99,14 @@ func GetUser(reqToken string) (*string, error) {
 func AddUserToContext(c *gin.Context) {
 	reqToken, err := GetRequestBearerToken(c)
 	if err != nil {
-		c.AbortWithError(http.StatusUnauthorized, err)
+    handleErr(c, fmt.Errorf("Unauthorized: %v", err))
+    c.Abort()
 		return
 	}
 	userEmail, err := GetUser(reqToken)
 	if err != nil {
-		c.AbortWithError(http.StatusUnauthorized, err)
+    handleErr(c, fmt.Errorf("Unauthorized: %v", err))
+    c.Abort()
 		return
 	}
 

--- a/internal/robokache/main_test.go
+++ b/internal/robokache/main_test.go
@@ -339,7 +339,11 @@ func TestPostChildWithData(t *testing.T) {
 			&signedString, &requestBody)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	newDocumentIDHash := w.Body.String()
+	var response map[string]interface{}
+  err := json.Unmarshal([]byte(w.Body.String()), &response)
+  assert.Nil(t, err)
+
+	newDocumentIDHash := response["id"].(string)
 	log.Println(newDocumentIDHash)
 
 	newDocumentID, err := hashToID(newDocumentIDHash)
@@ -350,7 +354,6 @@ func TestPostChildWithData(t *testing.T) {
 	w = performRequest(router, "GET",
 			fmt.Sprintf(`/api/document/%s`, newDocumentIDHash),
 			&signedString, &requestBody)
-	var response map[string]interface{}
 	err = json.Unmarshal([]byte(w.Body.String()), &response)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Nil(t, err)
@@ -371,8 +374,12 @@ func TestPostDocument(t *testing.T) {
 	w := performRequest(router, "POST", "/api/document", &signedString, &requestBody)
 	assert.Equal(t, http.StatusCreated, w.Code)
 
+	var response map[string]interface{}
+  err := json.Unmarshal([]byte(w.Body.String()), &response)
+  assert.Nil(t, err)
+
 	// Check that the ID was returned
-	createdID, err := hashToID(w.Body.String())
+	createdID, err := hashToID(response["id"].(string))
 	assert.Nil(t, err)
 	assert.Greater(t, createdID, 8)
 }
@@ -392,13 +399,18 @@ func TestPostDocumentWithMetadata(t *testing.T) {
 	w := performRequest(router, "POST", "/api/document", &signedString, &requestBody)
 	assert.Equal(t, http.StatusCreated, w.Code)
 
+	var response map[string]interface{}
+  err = json.Unmarshal([]byte(w.Body.String()), &response)
+  assert.Nil(t, err)
+
 	// Check that the metadata exists on object
-	createdID := w.Body.String()
+	createdID := response["id"].(string)
 	w = performRequest(router, "GET", "/api/document/" + createdID, &signedString, nil)
 	assert.Nil(t, err)
-	var response map[string]interface{}
+
 	err = json.Unmarshal([]byte(w.Body.String()), &response)
   assert.NotNil(t, response["metadata"])
+  t.Log(response)
   assert.Equal(t, metadata["hasAnswers"],
                   response["metadata"].(map[string]interface{})["hasAnswers"])
 }
@@ -413,8 +425,12 @@ func TestPostDocumentWithParent(t *testing.T) {
 	w := performRequest(router, "POST", "/api/document", &signedString, &requestBody)
 	assert.Equal(t, http.StatusCreated, w.Code)
 
+  var response map[string]interface{}
+  err := json.Unmarshal([]byte(w.Body.String()), &response)
+  assert.Nil(t, err)
+
 	// Check that the ID was returned
-	createdID, err := hashToID(w.Body.String())
+	createdID, err := hashToID(response["id"].(string))
 	assert.Nil(t, err)
 	assert.Greater(t, createdID, 8)
 }

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -21,7 +21,6 @@ func init() {
 func handleErr(c *gin.Context, err error) {
 	errorMsg := err.Error()
   errorResponse := map[string]string{
-    "status"  : "error",
     "message" : errorMsg,
   }
 	if strings.HasPrefix(errorMsg, "Bad Request") {
@@ -40,11 +39,6 @@ func handleErr(c *gin.Context, err error) {
 	}
 }
 
-func makeOkResponse() map[string]string {
-  return map[string]string{
-    "status" : "ok",
-  }
-}
 
 // AddGUI adds the GUI endpoints
 func AddGUI(r *gin.Engine) {
@@ -280,7 +274,7 @@ func SetupRouter() *gin.Engine {
 			}
 
 			// Return
-      response := makeOkResponse()
+      response := make(map[string]string)
       response["id"] = newDocIDHash
       c.JSON(http.StatusOK, response)
 		})
@@ -320,7 +314,7 @@ func SetupRouter() *gin.Engine {
 			}
 
 			// Return
-      response := makeOkResponse()
+      response := make(map[string]string)
       response["id"] = hashedID
       c.JSON(http.StatusCreated, response)
 		})
@@ -364,7 +358,7 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
-      response := makeOkResponse()
+      response := make(map[string]string)
       c.JSON(http.StatusOK, response)
 		})
 		authorized.PUT("/document/:id/data", func(c *gin.Context) {
@@ -393,7 +387,7 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
-      response := makeOkResponse()
+      response := make(map[string]string)
       c.JSON(http.StatusOK, response)
 		})
 		authorized.DELETE("/document/:id", func(c *gin.Context) {
@@ -417,7 +411,7 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
-      response := makeOkResponse()
+      response := make(map[string]string)
       c.JSON(http.StatusOK, response)
 		})
 	}


### PR DESCRIPTION
This change adds JSON responses for all routes. This makes the API more consistent and easier to interact with. Routes that used to return the ID as a text string now return an object that looks like this: 
```
{"status" : "ok", "id" : "idofcreated"}
```
Routes that don't need to return anything (PUT and DELETE) return the same thing as above but just with the status. Errors  now return JSON responses that look like this (in addition to setting the status code): 
```
{"status" : "error", "message" : "Error message"}
```

The only routes that don't necessarily have JSON responses and requests are the /data routes. This is expected since these routes use binary data.