### PR TITLE
Updated API to return 403s in addition to 404

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -3,7 +3,7 @@ openapi: 3.0.3
 info:
   title: Robokache
   description: Large object document store for ROBOKOP
-  version: 4.0.0
+  version: 4.1.0
   contact:
     email: patrick@covar.com
   license:
@@ -36,6 +36,8 @@ paths:
                    - $ref: '#/components/schemas/DocumentResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
     post:
       summary: Create a document
       requestBody:
@@ -52,6 +54,8 @@ paths:
                 allOf:
                  - $ref: '#/components/schemas/OkResponse'
                  - $ref: '#/components/schemas/IdOfCreated'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
   /api/document/{id}:
@@ -71,7 +75,7 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
-          $ref: '#/components/responses/NoSuchDocumentError'
+          $ref: '#/components/responses/NotFoundError'
     put:
       summary: Update fields of document
       parameters:
@@ -88,10 +92,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OkResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
         '404':
-          $ref: '#/components/responses/NoSuchDocumentError'
+          $ref: '#/components/responses/NotFoundError'
     delete:
       summary: Delete document by ID
       parameters:
@@ -103,10 +111,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OkResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
         '404':
-          $ref: '#/components/responses/NoSuchDocumentError'
+          $ref: '#/components/responses/NotFoundError'
   /api/document/{id}/children:
     get:
       summary: Get documents that have this document as a parent
@@ -126,7 +138,7 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '404':
-          $ref: '#/components/responses/NoSuchDocumentError'
+          $ref: '#/components/responses/NotFoundError'
     post:
       summary: Create a new child document and set data field
       description: Shorthand to create a child document and set the data field using only one route. This creates the document with default values for fields.
@@ -148,6 +160,10 @@ paths:
                 allOf:
                  - $ref: '#/components/schemas/OkResponse'
                  - $ref: '#/components/schemas/IdOfCreated'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   /api/document/{id}/data:
     get:
       summary: Get the data associated with this document
@@ -163,6 +179,8 @@ paths:
                 format: binary
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
     put:
       summary: Set the data associated with this document
       parameters:
@@ -183,6 +201,8 @@ paths:
                 $ref: '#/components/schemas/OkResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
 
 components:
   schemas:
@@ -222,14 +242,26 @@ components:
       scheme: bearer
       bearerFormat: jwt
   responses:
-    UnauthorizedError:
-      description: Access token is missing or invalid
+    BadRequestError:
+      description: Content of request is invalid
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
-    NoSuchDocumentError:
-      description: Document not found
+    UnauthorizedError:
+      description: Access token is malformed or invalid
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ForbiddenError:
+      description: You do not have permission to modify this document
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    NotFoundError:
+      description: Document not found or you do not have permission to view it
       content:
         application/json:
           schema:

--- a/internal/robokache/auth.go
+++ b/internal/robokache/auth.go
@@ -35,7 +35,7 @@ func issuedByGoogle(claims *jwt.MapClaims) bool {
 // Gets bearer (JWT) token from header
 // Only fails if the header is present and invalid
 func GetRequestBearerToken(c *gin.Context) (string, error) {
-	matchBearer := regexp.MustCompile("Bearer\\s([a-zA-Z0-9-_.]+)$")
+	matchBearer := regexp.MustCompile("^Bearer\\s([\\w.]+)$")
 
 	header := c.Request.Header
 	authorizationHeader := header.Get("Authorization")

--- a/internal/robokache/auth.go
+++ b/internal/robokache/auth.go
@@ -35,7 +35,7 @@ func issuedByGoogle(claims *jwt.MapClaims) bool {
 // Gets bearer (JWT) token from header
 // Only fails if the header is present and invalid
 func GetRequestBearerToken(c *gin.Context) (string, error) {
-	matchBearer := regexp.MustCompile("^Bearer\\s([\\w.]+)$")
+	matchBearer := regexp.MustCompile("^Bearer\\s([\\w.-]+)$")
 
 	header := c.Request.Header
 	authorizationHeader := header.Get("Authorization")
@@ -45,7 +45,7 @@ func GetRequestBearerToken(c *gin.Context) (string, error) {
 
 	bearer := matchBearer.FindStringSubmatch(authorizationHeader)
 	if bearer == nil {
-		return "", fmt.Errorf("Unauthorized: Invalid Authorization header formatting")
+		return "", fmt.Errorf("Invalid Authorization header formatting")
 	}
 
 	return bearer[1], nil

--- a/internal/robokache/delete.go
+++ b/internal/robokache/delete.go
@@ -7,9 +7,11 @@ import (
 // DeleteDocument deletes the document that matches the ID and Owner
 func DeleteDocument(doc Document) error {
 	result, err := db.Exec(`
-		DELETE FROM document WHERE
-		id=? AND owner=?;
-	`, doc.ID, doc.Owner)
+		DELETE FROM document WHERE id=?;
+	`, doc.ID)
+	if err != nil {
+		return err
+	}
 
 	rowsDeleted, err := result.RowsAffected()
 	if err != nil {

--- a/internal/robokache/put.go
+++ b/internal/robokache/put.go
@@ -9,26 +9,14 @@ import (
 )
 
 // EditDocument modifies the document with the given ID and updates the rest of the fields.
-func EditDocument(doc Document) error {
-
-	// Since this is a selective update request we may not be given fields
-	// So we have to pull it from the database
-	var existingDoc Document
-	err := db.Get(&existingDoc,
-		`SELECT * FROM document WHERE
-		 id=? AND owner=?`, doc.ID, doc.Owner)
-	if err == sql.ErrNoRows {
-		return fmt.Errorf("Bad Request: Check that the document exists and belongs to you.")
-	} else if err != nil {
-		return err
-	}
+func EditDocument(doc Document, existing Document) error {
 
 	// Fill in parent and visibility fields if not given
 	if doc.Parent == nil {
-		doc.Parent = existingDoc.Parent
+		doc.Parent = existing.Parent
 	}
 	if doc.Visibility == nil {
-		doc.Visibility = existingDoc.Visibility
+		doc.Visibility = existing.Visibility
 	}
 
 	// If the parent is still null the document has no parent

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -86,7 +86,6 @@ func SetupRouter() *gin.Engine {
 	{
 		api.GET("/document", func(c *gin.Context) {
 			userEmail := GetUserEmail(c)
-			log.WithFields(log.Fields{"email" : userEmail}).Debug("User email")
 			// userEmail will be nil here if the user is not logged in
 
 			// Parse query parameters into queryParams struct

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -20,21 +20,23 @@ func init() {
 
 func handleErr(c *gin.Context, err error) {
 	errorMsg := err.Error()
-  errorResponse := map[string]string{
-    "message" : errorMsg,
-  }
+	errorResponse := map[string]string{
+		"message" : errorMsg,
+	}
 	if strings.HasPrefix(errorMsg, "Bad Request") {
 		c.JSON(400, errorResponse)
 	} else if strings.HasPrefix(errorMsg, "Unauthorized") {
 		c.JSON(401, errorResponse)
+	} else if strings.HasPrefix(errorMsg, "Forbidden") {
+		c.JSON(403, errorResponse)
 	} else if strings.HasPrefix(errorMsg, "Not Found") {
 		c.JSON(404, errorResponse)
 	} else {
-    log.WithFields(log.Fields{"error" : err}).
-          WithContext(c).
-          Error("Internal Server Error")
-    // Rewrite error message so that we don't expose it to the user
-    errorResponse["message"] = "Internal Server Error"
+		log.WithFields(log.Fields{"error" : err}).
+		WithContext(c).
+		Error("Internal Server Error")
+		// Rewrite error message so that we don't expose it to the user
+		errorResponse["message"] = "Internal Server Error"
 		c.JSON(500, errorResponse)
 	}
 }
@@ -57,6 +59,15 @@ type GetDocumentQuery struct {
 	HasParent *bool `form:"has_parent"`
 }
 
+func GetUserEmail(c *gin.Context) (*string) {
+	val, ok := c.Get("userEmail")
+	if ok {
+		email, _ := val.(*string)
+		return email
+	}
+	return nil
+}
+
 // SetupRouter sets up the router
 func SetupRouter() *gin.Engine {
 	r := gin.Default()
@@ -67,31 +78,23 @@ func SetupRouter() *gin.Engine {
 	corsConfig.AllowHeaders =  []string{"Authorization", "Content-Type", "Accept"}
 
 	r.Use(cors.New(corsConfig))
+	r.Use(AddUserToContext)
 
 	api := r.Group("/api")
 
 	// GET endpoints don't necessarily require auth
 	{
 		api.GET("/document", func(c *gin.Context) {
-			var userEmail *string
-			// Check if we have been provided authorization
-			reqToken, err := GetRequestBearerToken(c)
-			// If we are given an authorization token
-			// get the user email associated
-			if err == nil {
-				userEmail, err = GetUser(reqToken)
-				// If the token is invalid, always abort
-				if err != nil {
-					handleErr(c, err)
-					return
-				}
-			} // userEmail will be nil here if the user is not logged in
+			userEmail := GetUserEmail(c)
+			log.WithFields(log.Fields{"email" : userEmail}).Debug("User email")
+			// userEmail will be nil here if the user is not logged in
 
 			// Parse query parameters into queryParams struct
 			var queryParams GetDocumentQuery
-			err = c.ShouldBindQuery(&queryParams)
+			err := c.ShouldBindQuery(&queryParams)
 			if err != nil {
 				handleErr(c, fmt.Errorf("Bad Request: Error parsing query parameters"))
+				return
 			}
 
 			// Get documents from database
@@ -115,15 +118,7 @@ func SetupRouter() *gin.Engine {
 			c.JSON(http.StatusOK, documents)
 		})
 		api.GET("/document/:id", func(c *gin.Context) {
-			var userEmail *string
-			reqToken, err := GetRequestBearerToken(c)
-			if err == nil {
-				userEmail, err = GetUser(reqToken)
-				if err != nil {
-					handleErr(c, err)
-					return
-				}
-			}
+			userEmail := GetUserEmail(c)
 
 			// Get document id
 			id, err := hashToID(c.Param("id"))
@@ -148,15 +143,7 @@ func SetupRouter() *gin.Engine {
 			c.JSON(http.StatusOK, document)
 		})
 		api.GET("/document/:id/data", func(c *gin.Context) {
-			var userEmail *string
-			reqToken, err := GetRequestBearerToken(c)
-			if err == nil {
-				userEmail, err = GetUser(reqToken)
-				if err != nil {
-					handleErr(c, err)
-					return
-				}
-			}
+			userEmail := GetUserEmail(c)
 
 			// Get document id
 			id, err := hashToID(c.Param("id"))
@@ -182,15 +169,7 @@ func SetupRouter() *gin.Engine {
 			}
 		})
 		api.GET("/document/:id/children", func(c *gin.Context) {
-			var userEmail *string
-			reqToken, err := GetRequestBearerToken(c)
-			if err == nil {
-				userEmail, err = GetUser(reqToken)
-				if err != nil {
-					handleErr(c, err)
-					return
-				}
-			}
+			userEmail := GetUserEmail(c)
 
 			// Get document id
 			id, err := hashToID(c.Param("id"))
@@ -227,100 +206,166 @@ func SetupRouter() *gin.Engine {
 		})
 	}
 
-	// Serve secured endpoints for all routes that can modify data
-	authorized := api.Group("")
-	authorized.Use(AddUserToContext)
-	{
-		authorized.POST("/document/:id/children", func(c *gin.Context) {
-			// Get user
-			userEmail := c.GetString("userEmail")
+	api.POST("/document/:id/children", func(c *gin.Context) {
+		userEmail := GetUserEmail(c)
+		if userEmail == nil {
+			handleErr(c,
+			fmt.Errorf("Unauthorized: You must be logged in to add a document."))
+			return
+		}
 
-			// Get document id
-			parentID, err := hashToID(c.Param("id"))
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
+		// Get document id
+		parentID, err := hashToID(c.Param("id"))
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
 
-			// Get the parent so we can set the default visibility
-			// to the visibility of the parent
-			parent, err := GetDocument(&userEmail, parentID)
-			if err != nil {
-				handleErr(c, err)
-			}
-			newDoc := Document{
-				Parent: &parent.ID,
-				Visibility: parent.Visibility,
-				Owner: userEmail,
-			}
+		// Get the parent so we can set the default visibility
+		// to the visibility of the parent
+		parent, err := GetDocument(userEmail, parentID)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+		newDoc := Document{
+			Parent: &parent.ID,
+			Visibility: parent.Visibility,
+			Owner: *userEmail,
+		}
 
-			// Add the document to the database
-			newDocID, err := PostDocument(newDoc)
-			if err != nil {
-				handleErr(c, err)
-			}
+		// Add the document to the database
+		newDocID, err := PostDocument(newDoc)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
 
-			// Write data to disk
-			err = SetData(newDocID, c.Request.Body)
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
+		// Write data to disk
+		err = SetData(newDocID, c.Request.Body)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
 
-			// Convert ID to hash
-			newDocIDHash, err := idToHash(newDocID)
-			if err != nil {
-				handleErr(c, err)
-			}
+		// Convert ID to hash
+		newDocIDHash, err := idToHash(newDocID)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
 
-			// Return
-      response := make(map[string]string)
-      response["id"] = newDocIDHash
-      c.JSON(http.StatusOK, response)
+		// Return
+		response := make(map[string]string)
+		response["id"] = newDocIDHash
+		c.JSON(http.StatusOK, response)
+	})
+
+	api.POST("/document", func(c *gin.Context) {
+		userEmail := GetUserEmail(c)
+		if userEmail == nil {
+			handleErr(c,
+			fmt.Errorf("Unauthorized: You must be logged in to add a document."))
+			return
+		}
+
+		// Parse the document from JSON
+		var doc Document
+		err := c.ShouldBindJSON(&doc)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+		// Set the document owner from the user's Google Auth
+		doc.Owner = *userEmail
+
+		// Convert user given hashes to IDs
+		err = doc.addID()
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		// Add document to DB
+		newID, err := PostDocument(doc)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		// Convert new ID to hash
+		hashedID, err := idToHash(newID)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		// Return
+		response := make(map[string]string)
+		response["id"] = hashedID
+		c.JSON(http.StatusCreated, response)
+	})
+	api.PUT("/document/:id", func(c *gin.Context) {
+		userEmail := GetUserEmail(c)
+		if userEmail == nil {
+			handleErr(c,
+			fmt.Errorf("Unauthorized: You must be logged in to edit a document."))
+			return
+		}
+
+		// Get document id
+		id, err := hashToID(c.Param("id"))
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		// Parse the document from JSON
+		var doc Document
+		err = c.ShouldBindJSON(&doc)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+		// Convert user-given parent hash and ID hash to IDs
+		err = doc.addID()
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		// Check we have permission to update this document
+		existingDoc, err := GetDocumentForEditing(*userEmail, id)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		// Set the document owner from the user's Google Auth
+		doc.Owner = *userEmail
+		// Set the document ID based on the URL param
+		doc.ID = id
+
+		// Add document to DB
+		err = EditDocument(doc, existingDoc)
+		if err != nil {
+			handleErr(c, err)
+			return
+		}
+
+		log.WithFields(
+			log.Fields{"doc" : fmt.Sprintf("%+v", doc)}).Debug("Updating document")
+
+			response := make(map[string]string)
+			c.JSON(http.StatusOK, response)
 		})
-		authorized.POST("/document", func(c *gin.Context) {
-			// Get user
-			userEmail := c.GetString("userEmail")
-
-			// Parse the document from JSON
-			var doc Document
-			err := c.ShouldBindJSON(&doc)
-			if err != nil {
-				handleErr(c, err)
+		api.PUT("/document/:id/data", func(c *gin.Context) {
+			userEmail := GetUserEmail(c)
+			if userEmail == nil {
+				handleErr(c,
+				fmt.Errorf("Unauthorized: You must be logged in to edit a document."))
 				return
 			}
-			// Set the document owner from the user's Google Auth
-			doc.Owner = userEmail
-
-			// Convert user given hashes to IDs
-			err = doc.addID()
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-
-			// Add document to DB
-			newID, err := PostDocument(doc)
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-
-			// Convert new ID to hash
-			hashedID, err := idToHash(newID)
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-
-			// Return
-      response := make(map[string]string)
-      response["id"] = hashedID
-      c.JSON(http.StatusCreated, response)
-		})
-		authorized.PUT("/document/:id", func(c *gin.Context) {
-			// Get user
-			userEmail := c.GetString("userEmail")
 
 			// Get document id
 			id, err := hashToID(c.Param("id"))
@@ -329,52 +374,8 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
-			// Parse the document from JSON
-			var doc Document
-			err = c.ShouldBindJSON(&doc)
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-			// Convert user-given parent hash and ID hash to IDs
-			err = doc.addID()
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-
-			log.WithFields(
-				log.Fields{"doc" : fmt.Sprintf("%+v", doc)}).Debug("Updating document")
-
-			// Set the document owner from the user's Google Auth
-			doc.Owner = userEmail
-			// Set the document based on the URL param
-			doc.ID = id
-
-			// Add document to DB
-			err = EditDocument(doc)
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-
-      response := make(map[string]string)
-      c.JSON(http.StatusOK, response)
-		})
-		authorized.PUT("/document/:id/data", func(c *gin.Context) {
-			// Get user
-			userEmail := c.GetString("userEmail")
-
-			// Get document id
-			id, err := hashToID(c.Param("id"))
-			if err != nil {
-				handleErr(c, err)
-				return
-			}
-
-			// Get document from database to ensure we have permission
-			// to access this endpoint
-			_, err = GetDocument(&userEmail, id)
+			// Check we have permission to update this document
+			_, err = GetDocumentForEditing(*userEmail, id)
 			if err != nil {
 				handleErr(c, err)
 				return
@@ -387,12 +388,16 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
-      response := make(map[string]string)
-      c.JSON(http.StatusOK, response)
+			response := make(map[string]string)
+			c.JSON(http.StatusOK, response)
 		})
-		authorized.DELETE("/document/:id", func(c *gin.Context) {
-			// Get user
-			userEmail := c.GetString("userEmail")
+		api.DELETE("/document/:id", func(c *gin.Context) {
+			userEmail := GetUserEmail(c)
+			if userEmail == nil {
+				handleErr(c,
+				fmt.Errorf("Unauthorized: You must be logged in to delete a document."))
+				return
+			}
 
 			// Get document id
 			id, err := hashToID(c.Param("id"))
@@ -401,20 +406,22 @@ func SetupRouter() *gin.Engine {
 				return
 			}
 
-			// Build a document object that is used to query the database for
-			// the delete request
-			doc := Document{ID: id, Owner: userEmail}
-
-			err = DeleteDocument(doc)
+			// Check we have permission to delete this document
+			existingDoc, err := GetDocumentForEditing(*userEmail, id)
 			if err != nil {
 				handleErr(c, err)
 				return
 			}
 
-      response := make(map[string]string)
-      c.JSON(http.StatusOK, response)
+			err = DeleteDocument(existingDoc)
+			if err != nil {
+				handleErr(c, err)
+				return
+			}
+
+			response := make(map[string]string)
+			c.JSON(http.StatusOK, response)
 		})
-	}
-	return r
+		return r
 
 }


### PR DESCRIPTION
When trying to update a public document that you do not own we are now returning a 403 instead of 404 to indicate that the action is forbidden. The API documentation has been updated to reflect this. This commit also includes some improvements to how auth error handling is structured. All routes use the same method for error handling (instead of having some routes on the `authorized` group). In addition, we are using a regex to match the Bearer token to make it clearer when the Authorization header is malformed.