### PR TITLE
Fix for error with empty document on the POST /api/document endpoint

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -212,6 +212,8 @@ components:
           type: string
         visibility:
           type: integer
+          default: 1
+          example: 1
         metadata:
           type: object
     DocumentResponse:

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -3,7 +3,7 @@ openapi: 3.0.3
 info:
   title: Robokache
   description: Large object document store for ROBOKOP
-  version: 4.1.0
+  version: 4.1.1
   contact:
     email: patrick@covar.com
   license:

--- a/internal/robokache/db.go
+++ b/internal/robokache/db.go
@@ -124,6 +124,13 @@ func clearDB() error {
 	return err
 }
 
+func makeDefaultDoc() Document {
+	defaultVisibility := private
+	return Document{
+		Visibility: &defaultVisibility,
+	}
+}
+
 func loadSampleData() error {
 	// Helper function to make an address from a constant
 	// The parent field needs to have a pointer to an int

--- a/internal/robokache/server.go
+++ b/internal/robokache/server.go
@@ -269,7 +269,7 @@ func SetupRouter() *gin.Engine {
 		}
 
 		// Parse the document from JSON
-		var doc Document
+		doc := makeDefaultDoc()
 		err := c.ShouldBindJSON(&doc)
 		if err != nil {
 			handleErr(c, err)


### PR DESCRIPTION
Sending an empty document (specifically one without visbility set) on
the document creation endpoint would cause null pointer execptions on
subsequent access (because the visibility is not set and is required for
some endpoints). Fixed this by addding a test case and adding a function
to retrieve a document with default values which is used in the POST
/api/document endpoint.